### PR TITLE
#13 user provided config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea
 .DS_Store
+home
+secret
 modules
 modulefiles
 base/rpms

--- a/README.md
+++ b/README.md
@@ -47,11 +47,11 @@ Steps to add user profided slurm.conf/slurmdbd.conf:
 
 1. Create ```home/config``` and ```secret``` directories: 
 
-```$ mkdir -p home/config secret```
+```mkdir -p home/config secret```
 
 2. Copy configuration files to the ```home/config``` directory:
 
-```$ cp <user-provided-slurm.conf> home/config/slurm.conf; cp <user-provided-slurmdbd.conf> home/config/slurmdbd.conf```
+```cp <user-provided-slurm.conf> home/config/slurm.conf; cp <user-provided-slurmdbd.conf> home/config/slurmdbd.conf```
 
 The user can then proceed as normal.
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,12 @@ The [Slurm Version 17.11 Configuration Tool](https://slurm.schedmd.com/configura
 
 Steps to add user profided slurm.conf/slurmdbd.conf:
 
-1. Create ```home/config``` and ```secret``` directories: ```$ mkdir -p home/config secret```
+1. Create ```home/config``` and ```secret``` directories: 
+
+```$ mkdir -p home/config secret```
+
 2. Copy configuration files to the ```home/config``` directory:
+
 ```$ cp <user-provided-slurm.conf> home/config/slurm.conf; cp <user-provided-slurmdbd.conf> home/config/slurmdbd.conf```
 
 The user can then proceed as normal.

--- a/README.md
+++ b/README.md
@@ -47,11 +47,15 @@ Steps to add user profided slurm.conf/slurmdbd.conf:
 
 1. Create ```home/config``` and ```secret``` directories: 
 
-```mkdir -p home/config secret```
+```
+mkdir -p home/config secret
+```
 
 2. Copy configuration files to the ```home/config``` directory:
 
-```cp <user-provided-slurm.conf> home/config/slurm.conf; cp <user-provided-slurmdbd.conf> home/config/slurmdbd.conf```
+```
+cp <user-provided-slurm.conf> home/config/slurm.conf; cp <user-provided-slurmdbd.conf> home/config/slurmdbd.conf
+```
 
 The user can then proceed as normal.
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,21 @@ database | Slurm Primary Database Daemon | database.local.dev
 worker01 | Slurm Worker | worker01.local.dev
 worker02 | Slurm Worker | worker02.local.dev
 
+## Configure slurm.conf/slurmdbd.conf
+
+Users may use the default slurm.conf file generated in [docker-entrypoint.sh](https://github.com/SciDAS/slurm-in-docker/blob/master/controller/docker-entrypoint.sh), or preferably create one to better fit their system. 
+
+The [Slurm Version 17.11 Configuration Tool](https://slurm.schedmd.com/configurator.html) is a useful resource for creating custom slurm.conf files.
+
+Steps to add user profided slurm.conf/slurmdbd.conf:
+
+1. Create ```home/config``` and ```secret``` directories: ```$ mkdir -p home/config secret```
+2. Copy configuration files to the ```home/config``` directory: ```$ cp <user-provided-slurm.conf> home/config/slurm.conf; cp <user-provided-slurmdbd.conf> home/config/slurmdbd.conf```
+
+The user can then proceed as normal.
+
+TODO: Have software check validity of custom configuration files.
+
 ## Build
 
 Build the slurm RPM files by following the instructions in the [packages](packages) directory.

--- a/README.md
+++ b/README.md
@@ -46,7 +46,8 @@ The [Slurm Version 17.11 Configuration Tool](https://slurm.schedmd.com/configura
 Steps to add user profided slurm.conf/slurmdbd.conf:
 
 1. Create ```home/config``` and ```secret``` directories: ```$ mkdir -p home/config secret```
-2. Copy configuration files to the ```home/config``` directory: ```$ cp <user-provided-slurm.conf> home/config/slurm.conf; cp <user-provided-slurmdbd.conf> home/config/slurmdbd.conf```
+2. Copy configuration files to the ```home/config``` directory:
+```$ cp <user-provided-slurm.conf> home/config/slurm.conf; cp <user-provided-slurmdbd.conf> home/config/slurmdbd.conf```
 
 The user can then proceed as normal.
 

--- a/config/slurm.conf.example
+++ b/config/slurm.conf.example
@@ -8,8 +8,8 @@
 #
 # See the slurm.conf man page for more information.
 #
-ClusterName=linux
-ControlMachine=linux0
+ClusterName=snowflake
+ControlMachine=controller
 #ControlAddr=
 #BackupController=
 #BackupAddr=
@@ -79,15 +79,16 @@ JobCompType=jobcomp/none
 #JobCompLoc=
 #
 # ACCOUNTING
-#JobAcctGatherType=jobacct_gather/linux
+JobAcctGatherType=jobacct_gather/linux
 #JobAcctGatherFrequency=30
 #
-#AccountingStorageType=accounting_storage/slurmdbd
-#AccountingStorageHost=
+AccountingStorageType=accounting_storage/slurmdbd
+AccountingStorageHost=database
+AccountingStoragePort=6819
 #AccountingStorageLoc=
 #AccountingStoragePass=
 #AccountingStorageUser=
 #
 # COMPUTE NODES
-NodeName=linux[1-32] Procs=1 State=UNKNOWN
-PartitionName=debug Nodes=ALL Default=YES MaxTime=INFINITE State=UP
+NodeName=worker[01-02] RealMemory=1800 CPUs=1 State=UNKNOWN
+PartitionName=docker Nodes=ALL Default=YES MaxTime=INFINITE State=UP

--- a/config/slurmdbd.conf.example
+++ b/config/slurmdbd.conf.example
@@ -13,12 +13,12 @@
 #
 # Authentication info
 AuthType=auth/munge
-#AuthInfo=/var/run/munge/munge.socket.2
+AuthInfo=/var/run/munge/munge.socket.2
 #
 # slurmDBD info
-DbdAddr=localhost
-DbdHost=localhost
-#DbdPort=7031
+DbdAddr=database
+DbdHost=database
+DbdPort=6819
 SlurmUser=slurm
 #MessageTimeout=300
 DebugLevel=4
@@ -31,9 +31,8 @@ PidFile=/var/run/slurmdbd.pid
 #
 # Database info
 StorageType=accounting_storage/mysql
-#StorageHost=localhost
-#StoragePort=1234
+StorageHost=database.local.dev
+StoragePort=3306
 StoragePass=password
 StorageUser=slurm
-#StorageLoc=slurm_acct_db
-
+StorageLoc=slurm_acct_db

--- a/controller/docker-entrypoint.sh
+++ b/controller/docker-entrypoint.sh
@@ -12,6 +12,10 @@ _sshd_host() {
 
 # setup worker ssh to be passwordless
 _ssh_worker() {
+  if [[ ! -d /home/worker ]]; then
+    mkdir -p /home/worker
+    chown -R worker:worker /home/worker
+  fi
   cat > /home/worker/setup-worker-ssh.sh <<'EOF2'
 mkdir -p ~/.ssh
 chmod 0700 ~/.ssh
@@ -175,7 +179,13 @@ _slurmctld() {
     /var/log/slurm
   touch /var/log/slurmctld.log
   chown slurm: /var/log/slurmctld.log
-  _generate_slurm_conf
+  if [[ ! -f /home/config/slurm.conf ]]; then
+    echo "### generate slurm.conf ###"
+    _generate_slurm_conf
+  else
+    echo "### use provided slurm.conf ###"
+    cp /home/config/slurm.conf /etc/slurm/slurm.conf
+  fi
   sacctmgr -i add cluster ${CLUSTER_NAME}
   sleep 2s
   /usr/sbin/slurmctld

--- a/database/docker-entrypoint.sh
+++ b/database/docker-entrypoint.sh
@@ -118,7 +118,13 @@ _slurmdbd() {
     /var/log/slurm
   chown slurm: /var/spool/slurm/d \
     /var/log/slurm
-  _generate_slurmdbd_conf
+  if [[ ! -f /home/config/slurmdbd.conf ]]; then
+    echo "### generate slurmdbd.conf ###"
+    _generate_slurmdbd_conf
+  else
+    echo "### use provided slurmdbd.conf ###"
+    cp /home/config/slurmdbd.conf /etc/slurm/slurmdbd.conf
+  fi
   /usr/sbin/slurmdbd
   cp /etc/slurm/slurmdbd.conf /.secret/slurmdbd.conf
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     container_name: controller
     privileged: true
     volumes:
-      - home:/home
-      - secret:/.secret
+      - ./home:/home
+      - ./secret:/.secret
     restart: always
     hostname: controller.local.dev
     networks:
@@ -36,8 +36,8 @@ services:
     container_name: database
     privileged: true
     volumes:
-      - home:/home
-      - secret:/.secret
+      - ./home:/home
+      - ./secret:/.secret
     restart: always
     hostname: database.local.dev
     networks:
@@ -61,8 +61,8 @@ services:
     container_name: worker01
     privileged: true
     volumes:
-      - home:/home
-      - secret:/.secret
+      - ./home:/home
+      - ./secret:/.secret
     restart: always
     hostname: worker01.local.dev
     networks:
@@ -82,8 +82,8 @@ services:
     container_name: worker02
     privileged: true
     volumes:
-      - home:/home
-      - secret:/.secret
+      - ./home:/home
+      - ./secret:/.secret
     restart: always
     hostname: worker02.local.dev
     networks:
@@ -92,10 +92,6 @@ services:
       CONTROL_MACHINE: controller
       ACCOUNTING_STORAGE_HOST: database
       COMPUTE_NODES: worker01 worker02
-
-volumes:
-  home:
-  secret:
 
 networks:
   slurm:


### PR DESCRIPTION
- Allow user to pass configuraiton file for slurm.conf and slurmdbd.conf via the `/home/config` directory within the container.
- updated `docker-compose.yml` to use local volume mounts for `home` and `secret` for testing purposes
- provide default `slurm.conf.example` and `slurmdbd.conf.example` files in `config` directory to serve as working examples

Steps to test

1. create two new local directories `$ mkdir -p home/config secret`
2. copy example config files to the `home/config` directory `$ cp config/slurm.conf.example home/config/slurm.conf; cp config/slurmdbd.conf.example home/config/slurmdbd.conf`
3. run the compose file as a non-daemon `$ docker-compose up`
4. validate that passed in files are being picked up.

```console
$ docker-compose up
Creating controller ... done
Creating worker01   ... done
Creating worker02   ... done
Creating database   ... done
Attaching to controller, database, worker02, worker01
...
database      |
database      | 2018-05-15 15:51:19 Spawning 1 thread for encoding
database      | 2018-05-15 15:51:19 Processing credentials for 1 second
database      | 2018-05-15 15:51:20 Processed 8786 credentials in 1.000s (8783 creds/sec)
database      | ### use provided slurmdbd.conf ###        <-- THIS
controller    | cheking for slurmdbd.conf.......
controller    | ### use provided slurm.conf ###           <-- AND THIS
controller    |  Adding Cluster(s)
controller    |   Name           = snowflake
worker02      | cheking for slurm.conf........
worker01      | cheking for slurm.conf........
```
5. test the rest of the functions per usual method